### PR TITLE
Request added to response and response error

### DIFF
--- a/src/attach.js
+++ b/src/attach.js
@@ -16,8 +16,16 @@ function interceptor(fetch, ...args) {
     }
   });
 
+  let request = null;
+
   // Register fetch call
-  promise = promise.then(args => fetch(...args));
+  promise = promise.then(args => {
+    request = new Request(...args);
+    return fetch(request);
+  }).then(response => {
+    response.request = request;
+    return response;
+  });
 
   // Register response interceptors
   reversedInterceptors.forEach(({ response, responseError }) => {

--- a/src/attach.js
+++ b/src/attach.js
@@ -16,18 +16,16 @@ function interceptor(fetch, ...args) {
     }
   });
 
-  let request = null;
-
   // Register fetch call
   promise = promise.then(args => {
-    request = new Request(...args);
-    return fetch(request);
-  }).then(response => {
-    response.request = request;
-    return response;
-  }).catch(error => {
-    error.request = request;
-    return Promise.reject(error);
+    const request = new Request(...args);
+    return fetch(request).then(response => {
+      response.request = request;
+      return response;
+    }).catch(error => {
+      error.request = request;
+      return Promise.reject(error);
+    });
   });
 
   // Register response interceptors

--- a/src/attach.js
+++ b/src/attach.js
@@ -25,6 +25,9 @@ function interceptor(fetch, ...args) {
   }).then(response => {
     response.request = request;
     return response;
+  }).catch(error => {
+    error.request = request;
+    return Promise.reject(error);
   });
 
   // Register response interceptors

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,13 @@
 // Typescript definition file
 declare module 'fetch-intercept' {
+  export interface FetchInterceptorResponse extends Response {
+    request: Request;
+  }
+
   export interface FetchInterceptor {
     request?(url: string, config: any): Promise<any[]> | any[];
     requestError?(error: any): Promise<any>;
-    response?(response: Response): Response;
+    response?(response: FetchInterceptorResponse): FetchInterceptorResponse;
     responseError?(error: any): Promise<any>;
   }
 


### PR DESCRIPTION
Add the request in the response.

It help when you intercept an error and want to resend the request.

(I used to work like this with axios, and this feature is missing with fetch)

PS: Hope the commit history is now clean enough ;)