### PR TITLE
Cloning Request so that it can be used for retry fetch

### DIFF
--- a/src/attach.js
+++ b/src/attach.js
@@ -19,11 +19,14 @@ function interceptor(fetch, ...args) {
   // Register fetch call
   promise = promise.then(args => {
     const request = new Request(...args);
+    const cloneRequest = request.clone();
     return fetch(request).then(response => {
       response.request = request;
+      response.cloneRequest = cloneRequest;
       return response;
     }).catch(error => {
       error.request = request;
+      error.cloneRequest = cloneRequest;
       return Promise.reject(error);
     });
   });


### PR DESCRIPTION
Cloning request object and sending back in response or error of fetch so that it can be used for retry logic with request. Using existing request object for retry throws an error as body is already read and used so cloning it